### PR TITLE
Shrinkes the vlog.Iter struct from 104 to 64 bytes

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -292,7 +292,7 @@ func (b *bucket) logAt(loc item.Location) vlog.Iter {
 func (b *bucket) addIter(batchIters *vlog.Iters, idxIter *index.Iter) (bool, error) {
 	loc := idxIter.Value()
 	batchIter := b.logAt(loc)
-	if !batchIter.Next() {
+	if !batchIter.Next(b.log) {
 		// might be empty or I/O error:
 		return false, batchIter.Err()
 	}
@@ -384,7 +384,7 @@ func (b *bucket) peek(n int, dst item.Items, idx *index.Index) (batchIters *vlog
 		// advance current batch iter. We will make sure at the
 		// end of the loop that the currently first one gets sorted
 		// correctly if it turns out to be out-of-order.
-		currIter.Next()
+		currIter.Next(b.log)
 		currKey := currIter.Item().Key
 		if err := currIter.Err(); err != nil {
 			return nil, dst, 0, err
@@ -494,7 +494,7 @@ func (b *bucket) Delete(fork ForkName, from, to item.Key) (ndeleted int, outErr 
 		rightLoc := item.Location{}
 
 		logIter := b.logAt(loc)
-		for logIter.Next() {
+		for logIter.Next(b.log) {
 			item := logIter.Item()
 			if item.Key < from {
 				// key is not affected by the deletion; keep it.

--- a/bucket.go
+++ b/bucket.go
@@ -292,9 +292,9 @@ func (b *bucket) logAt(loc item.Location) vlog.Iter {
 func (b *bucket) addIter(batchIters *vlog.Iters, idxIter *index.Iter) (bool, error) {
 	loc := idxIter.Value()
 	batchIter := b.logAt(loc)
-	if !batchIter.Next(b.log) {
+	if err := vlog.IterReportNonExhaustError(batchIter.Next(b.log)); err != nil {
 		// might be empty or I/O error:
-		return false, batchIter.Err()
+		return false, err
 	}
 
 	batchIters.Push(batchIter)
@@ -384,9 +384,9 @@ func (b *bucket) peek(n int, dst item.Items, idx *index.Index) (batchIters *vlog
 		// advance current batch iter. We will make sure at the
 		// end of the loop that the currently first one gets sorted
 		// correctly if it turns out to be out-of-order.
-		currIter.Next(b.log)
+		err := currIter.Next(b.log)
 		currKey := currIter.Item().Key
-		if err := currIter.Err(); err != nil {
+		if err := vlog.IterReportNonExhaustError(err); err != nil {
 			return nil, dst, 0, err
 		}
 
@@ -494,7 +494,7 @@ func (b *bucket) Delete(fork ForkName, from, to item.Key) (ndeleted int, outErr 
 		rightLoc := item.Location{}
 
 		logIter := b.logAt(loc)
-		for logIter.Next(b.log) {
+		for err := logIter.Next(b.log); err == nil; err = logIter.Next(b.log) {
 			item := logIter.Item()
 			if item.Key < from {
 				// key is not affected by the deletion; keep it.

--- a/cmd/parser/parser.go
+++ b/cmd/parser/parser.go
@@ -333,7 +333,8 @@ func handleLogDump(ctx *cli.Context) error {
 	}
 
 	var loc = item.Location{Len: 1e9}
-	for iter := log.At(loc, true); iter.Next(log); {
+	iter := log.At(loc, true)
+	for err := iter.Next(log); err == nil; err = iter.Next(log) {
 		it := iter.Item()
 		fmt.Printf("%v:%s\n", it.Key, it.Blob)
 	}

--- a/cmd/parser/parser.go
+++ b/cmd/parser/parser.go
@@ -333,7 +333,7 @@ func handleLogDump(ctx *cli.Context) error {
 	}
 
 	var loc = item.Location{Len: 1e9}
-	for iter := log.At(loc, true); iter.Next(); {
+	for iter := log.At(loc, true); iter.Next(log); {
 		it := iter.Item()
 		fmt.Printf("%v:%s\n", it.Key, it.Blob)
 	}

--- a/index/index.go
+++ b/index/index.go
@@ -35,7 +35,8 @@ func FromVlog(log *vlog.Log) (*Index, error) {
 
 	// Go over the data and try to find runs of data that are sorted in
 	// ascending order. Each deviant item is the start of a new run.
-	for iter.Next(log) {
+	errIter := iter.Next(log)
+	for ; errIter == nil; errIter = iter.Next(log) {
 		it := iter.Item()
 		if prevLoc.Key > it.Key {
 			index.Set(lastLoc)
@@ -54,7 +55,7 @@ func FromVlog(log *vlog.Log) (*Index, error) {
 		prevLoc.Key = it.Key
 	}
 
-	if err := iter.Err(); err != nil {
+	if err := vlog.IterReportNonExhaustError(errIter); err != nil {
 		return nil, err
 	}
 

--- a/index/index.go
+++ b/index/index.go
@@ -35,7 +35,7 @@ func FromVlog(log *vlog.Log) (*Index, error) {
 
 	// Go over the data and try to find runs of data that are sorted in
 	// ascending order. Each deviant item is the start of a new run.
-	for iter.Next() {
+	for iter.Next(log) {
 		it := iter.Item()
 		if prevLoc.Key > it.Key {
 			index.Set(lastLoc)

--- a/vlog/iter.go
+++ b/vlog/iter.go
@@ -11,7 +11,6 @@ import (
 //
 // Possible ideas to get down from 104 to 64:
 //
-//   - Use only one len field. -> -8
 //   - Always pass Item out on Next() as out param. -> -32
 //     -> Not possible, because the item might not be consumed directly
 //     as we might realize that another iter has more priority.
@@ -22,7 +21,7 @@ type Iter struct {
 	firstKey         item.Key
 	currOff, prevOff item.Off
 	item             item.Item
-	currLen, prevLen item.Off   // Only one length field, 8 bytes.
+	currLen          item.Off
 	exhausted        bool       // Merge flags with currLen to a currLenFlags field, 8 bytes.
 	continueOnErr    bool
 }
@@ -61,7 +60,6 @@ func (li *Iter) Next(log *Log) error {
 	}
 
 	li.prevOff = li.currOff
-	li.prevLen = li.currLen
 
 	// advance iter to next position:
 	li.currOff += item.Off(li.item.StorageSize())
@@ -92,7 +90,7 @@ func (li *Iter) CurrentLocation() item.Location {
 	return item.Location{
 		Key: li.item.Key,
 		Off: li.prevOff,
-		Len: li.prevLen,
+		Len: li.currLen + 1,
 	}
 }
 

--- a/vlog/iter_test.go
+++ b/vlog/iter_test.go
@@ -36,7 +36,7 @@ func TestIter(t *testing.T) {
 
 	var count int
 	iter := log.At(loc, true)
-	for iter.Next() {
+	for iter.Next(log) {
 		it := iter.Item()
 		require.Equal(t, item.Item{
 			Key:  item.Key(count + 10),
@@ -69,7 +69,7 @@ func TestIterEmpty(t *testing.T) {
 	require.NoError(t, err)
 	iter := log.At(item.Location{}, true)
 
-	require.False(t, iter.Next())
+	require.False(t, iter.Next(log))
 	require.NoError(t, iter.Err())
 	require.NoError(t, log.Close())
 }
@@ -88,7 +88,7 @@ func TestIterInvalidLocation(t *testing.T) {
 		Len: 1000,
 	}, true)
 
-	require.False(t, iter.Next())
+	require.False(t, iter.Next(log))
 	require.True(t, iter.Exhausted())
 	require.NoError(t, iter.Err())
 	require.NoError(t, log.Close())
@@ -131,12 +131,12 @@ func testIterBrokenStream(t *testing.T, overwriteIndex int, continueOnErr bool) 
 	// value at least:
 	iter := log.At(loc, continueOnErr)
 	if continueOnErr {
-		require.True(t, iter.Next())
+		require.True(t, iter.Next(log))
 		it := iter.Item()
 		require.Equal(t, item.Key(42), it.Key)
 		require.Equal(t, item2.Blob, it.Blob)
 	}
-	require.False(t, iter.Next())
+	require.False(t, iter.Next(log))
 }
 
 func TestIterHeap(t *testing.T) {

--- a/vlog/vlog.go
+++ b/vlog/vlog.go
@@ -191,7 +191,7 @@ func (l *Log) At(loc item.Location, continueOnErr bool) Iter {
 	return Iter{
 		firstKey:      loc.Key,
 		currOff:       loc.Off,
-		currLen:       loc.Len,
+		currLen:       uint32(loc.Len),
 		continueOnErr: continueOnErr,
 	}
 }

--- a/vlog/vlog.go
+++ b/vlog/vlog.go
@@ -192,7 +192,6 @@ func (l *Log) At(loc item.Location, continueOnErr bool) Iter {
 		firstKey:      loc.Key,
 		currOff:       loc.Off,
 		currLen:       loc.Len,
-		log:           l,
 		continueOnErr: continueOnErr,
 	}
 }

--- a/vlog/vlog_test.go
+++ b/vlog/vlog_test.go
@@ -92,20 +92,20 @@ func TestLogShrink(t *testing.T) {
 	require.NoError(t, err)
 
 	iter := log.At(firstLoc, true)
-	require.True(t, iter.Next())
+	require.True(t, iter.Next(log))
 	require.Equal(t, item.Item{
 		Key:  1,
 		Blob: []byte("1"),
 	}, iter.Item())
-	require.False(t, iter.Next())
+	require.False(t, iter.Next(log))
 
 	iter = log.At(sndLoc, true)
-	require.True(t, iter.Next())
+	require.True(t, iter.Next(log))
 	require.Equal(t, item.Item{
 		Key:  2,
 		Blob: []byte("2"),
 	}, iter.Item())
-	require.False(t, iter.Next())
+	require.False(t, iter.Next(log))
 
 	require.NoError(t, iter.Err())
 	require.NoError(t, log.Close())

--- a/vlog/vlog_test.go
+++ b/vlog/vlog_test.go
@@ -92,22 +92,21 @@ func TestLogShrink(t *testing.T) {
 	require.NoError(t, err)
 
 	iter := log.At(firstLoc, true)
-	require.True(t, iter.Next(log))
+	require.NoError(t, IterReportNonExhaustError(iter.Next(log)))
 	require.Equal(t, item.Item{
 		Key:  1,
 		Blob: []byte("1"),
 	}, iter.Item())
-	require.False(t, iter.Next(log))
+	require.Error(t, iter.Next(log))
 
 	iter = log.At(sndLoc, true)
-	require.True(t, iter.Next(log))
+	require.NoError(t, IterReportNonExhaustError(iter.Next(log)))
 	require.Equal(t, item.Item{
 		Key:  2,
 		Blob: []byte("2"),
 	}, iter.Item())
-	require.False(t, iter.Next(log))
+	require.Error(t, iter.Next(log))
 
-	require.NoError(t, iter.Err())
 	require.NoError(t, log.Close())
 }
 


### PR DESCRIPTION
Unfortunately, the benchmark shows no differences before and after the change.